### PR TITLE
Publish the "why assemble" page

### DIFF
--- a/src/templates/pages/docs/Why-Assemble.md.hbs
+++ b/src/templates/pages/docs/Why-Assemble.md.hbs
@@ -1,6 +1,5 @@
 ---
 title: Why Assemble?
-published: false
 section: getting started
 ---
 


### PR DESCRIPTION
The [about page](http://assemble.io/docs/About.html) has [a link](https://github.com/assemble/assemble-docs/blob/e15e87f5d738dfbcc40cc5882213ad60c6246822/src/templates/pages/docs/About.md.hbs#L24) to [this page](http://assemble.io/docs/Why-Assemble.html), but it is not currently published.
