### PR TITLE
Remove link to "why assemble" page

### DIFF
--- a/src/templates/pages/docs/About.md.hbs
+++ b/src/templates/pages/docs/About.md.hbs
@@ -21,7 +21,6 @@ Which really means "if you put your posts in a specific folder, and you name it 
 
 ## Learn more
 
-* [Why Assemble?][why-assemble]
 * [Options][]
 * [variables][built-in-variables]
 * [Templates][]


### PR DESCRIPTION
This page is [not currently published](http://assemble.io/docs/Why-Assemble.html).
