### PR TITLE
Updated the see the template for this page link to be correct path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "assemble-docs",
+  "version": "0.1.4",
+  "main": [
+    "Gruntfile.js"
+  ],
+  "devDependencies": {
+    "assemble": "~0.4.3",
+    "assemble-less": "~0.5.3",
+    "grunt": "~0.4.1",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-copy": "~0.4.1",
+    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-github-api": "~0.1.2",
+    "highlight.js": "~7.3.0",
+    "js-beautify": "~1.4.0",
+    "lodash": "~1.3.1",
+    "matchdep": "~0.1.2",
+    "time-grunt": "~0.1.1",
+    "grunt-newer": "~0.5.1",
+    "grunt-sync-pkg": "~0.1.0",
+    "helper-prettify": "~0.1.3"
+  }
+}

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -37,7 +37,7 @@ layout: base.hbs
           {{> body }} {{> generated-links.md }}
         {{/markdown}}
         <hr>
-        <p><a href="{{site.templates.view}}/{{area}}/{{this.basename}}.hbs">See the template for this page → </a></p>
+        <p><a href="{{site.templates.view}}/{{area}}/{{this.basename}}.md.hbs">See the template for this page → </a></p>
         {{> footer }}
       </div>
     </div>


### PR DESCRIPTION
The paths on the documentation pages are pointing to *.hbs where the github url should be *.md.hbs

Visit:
http://assemble.io/docs/About.html
View: See the template for this page → url
