### PR TITLE
TOC for helpers section using assemble-contrib-toc plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "template": "~0.1.5",
     "underscore.string": "~2.3.3",
     "shelljs": "~0.2.6",
-    "remote-origin-url": "^0.2.1"
+    "remote-origin-url": "^0.2.1",
+    "assemble-contrib-toc": "^0.1.2"
   },
   "keywords": [
     "assemble",

--- a/structure/pages/helpers.hbs
+++ b/structure/pages/helpers.hbs
@@ -5,5 +5,8 @@ slug: helpers
 <!-- inner navigation (for content) -->
 {{> navbar-content }}
 
+<h1>Table of Content</h1>
+<div id="toc"></div>
+
 <!-- See `structure/includes/docs.hbs` and `data/helpers.yml` -->
 {{> docs helpers.published }}


### PR DESCRIPTION
I did not test it since I am unable to build all pages, but it shall work.
