### PR TITLE
Corrected source path in pages collections example

### DIFF
--- a/templates/pages/docs/Pages-Collections.md.hbs
+++ b/templates/pages/docs/Pages-Collections.md.hbs
@@ -36,12 +36,12 @@ assemble: {
   },
   docs: {
     files: {
-      'docs/': ['src/docs/pages/*.hbs'],
+      'docs/': ['src/docs/*.hbs'],
     }
   },
   blog: {
     files: {
-      'blog/': ['src/blog/posts/*.hbs'],
+      'blog/': ['src/posts/*.hbs'],
     }
   }
 }


### PR DESCRIPTION
Corrected the source path in the example to match the file structure shown above it in the pages collection documentation.
