### PR TITLE
Fix broken link

### DIFF
--- a/templates/pages/docs/Markdown.md.hbs
+++ b/templates/pages/docs/Markdown.md.hbs
@@ -128,4 +128,4 @@ In a layout, can also wrap the `\{{> body }}` tag with the `\{{#markdown}}...\{{
 
 ## Related Information
 
-* [options.marked][options-markded]
+* [options.marked][options-marked]


### PR DESCRIPTION
Also, I composed this description for important use-case for {{#markdown}}, but not sure how to put markdown in markdown in markdown:

The markdown block can also be used to continue parsing markdown content within an html tag that would normally not be processed as markdown:

`````` markdown
## My Header

Some more markdown

<div class='my class'>
{{#markdown}}
```js
//now my code will be pretty!
var a = 1 + 2;
`` //github choking on escaped 3rd tick
{{/markdown}}
</div>
``````
