### PR TITLE
fix minor typo

### DIFF
--- a/templates/pages/helpers/index.hbs
+++ b/templates/pages/helpers/index.hbs
@@ -44,7 +44,7 @@ Handlebars.js ships with some built-in helpers, such as `\{{#each}}`, `\{{#if}}`
 Handlebars allows two different kinds of helpers:
 
 * **Expression helpers** are basically regular functions that take the name of the helper and the helper function as arguments. Once an expression helper is registered, it can be called anywhere in your templates, then Handlebars takes the expression's return value and writes it into the template.
-* **Block helpers** There are a few block helpers included by default with Handlebars, `\{{#each}}`, `\{{#if}}` and `\{{#unless}}`. Custom block helpers are registered the same way as exptression helpers, but the difference is that Handlebars will pass the contents of the block compiled into a function to the helper.
+* **Block helpers** There are a few block helpers included by default with Handlebars, `\{{#each}}`, `\{{#if}}` and `\{{#unless}}`. Custom block helpers are registered the same way as expression helpers, but the difference is that Handlebars will pass the contents of the block compiled into a function to the helper.
 
 Learn about [adding custom helpers](http://assemble.io/docs/Custom-Helpers.html) to Assemble.
 


### PR DESCRIPTION
fix typo in word 'expression' in block helpers section
