### PR TITLE
Trying to add my first assemble plugin

### DIFF
--- a/templates/pages/plugins/index.hbs
+++ b/templates/pages/plugins/index.hbs
@@ -23,6 +23,7 @@ If you authored an Assemble plugin, please submit a pull request to add it to th
 
 * [assemble-markdown-data](https://github.com/adjohnson916/assemble-markdown-data): An Assemble plugin for automatic parsing of markdown in data.
 * [assemble-related-pages](https://github.com/adjohnson916/assemble-related-pages): An Assemble plugin for generating lists of related pages.
+* [assemble-dox](https://github.com/gionkunz/assemble-dox): An Assemble plugin for generating JavaScript API documentation using dox.
 
 ## Plugins we want
 


### PR DESCRIPTION
Hi there
I'm using assemble a lot and love its flexibility. I'm using it mostly as a static site generator for styleguides, prototypes and the like. I've already used dox to write some YML files that can be read by assemble, so I can also generate my JavaScript API documentation using assemble. I'm using this currently for my project Chartist.js http://gionkunz.github.io/chartist-js/ . However, I've figured it would be much nicer to have this included as a plugin and that's why I've created assemble-dox.

Hope you guys still willed to include this as you are also working on new major versions as far as I know.

Cheers
Gion
