### PR TITLE
Added assemble-markedown-pages

### DIFF
--- a/templates/pages/plugins/index.hbs
+++ b/templates/pages/plugins/index.hbs
@@ -24,6 +24,7 @@ If you authored an Assemble plugin, please submit a pull request to add it to th
 * [assemble-markdown-data](https://github.com/adjohnson916/assemble-markdown-data): An Assemble plugin for automatic parsing of markdown in data.
 * [assemble-related-pages](https://github.com/adjohnson916/assemble-related-pages): An Assemble plugin for generating lists of related pages.
 * [assemble-dox](https://github.com/gionkunz/assemble-dox): An Assemble plugin for generating JavaScript API documentation using dox.
+* [assemble-markdown-pages](https://github.com/matthewfowles/assemble-markdown-pages): An Assemble plugin for generating pages directly from markdown files.
 
 ## Plugins we want
 


### PR DESCRIPTION
I have created a plugin that takes markdown files with optional YFM and outputs them directly to html. This plugin is currently used on my site to generate Markdown posts into pages. Would like to make it available to the larger community.