### PR TITLE
Incorrect word used

### DIFF
--- a/docs/Pages-Collections.html
+++ b/docs/Pages-Collections.html
@@ -355,7 +355,7 @@
   &lt;li&gt;&lt;a href=&quot;#&quot;&gt;api&lt;/a&gt;&lt;/li&gt;
   &lt;li&gt;&lt;a href=&quot;#&quot;&gt;cheatsheet&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;</code></pre>
-            <p>When we build the project, and pages from the <code>block</code> target will render with:</p>
+            <p>When we build the project, and pages from the <code>blog</code> target will render with:</p>
             <pre><code class="language-html">&lt;ul&gt;
   &lt;li&gt;&lt;a href=&quot;#&quot;&gt;index&lt;/a&gt;&lt;/li&gt;
   &lt;li&gt;&lt;a href=&quot;#&quot;&gt;articles&lt;/a&gt;&lt;/li&gt;


### PR DESCRIPTION
The target was mentioned as block and should have been blog as in targets described above.